### PR TITLE
ENH: add accelerator PV linking functionality

### DIFF
--- a/Arbiter/ArbiterPLC/POUs/Accelerator/FB_Hgvpu.TcPOU
+++ b/Arbiter/ArbiterPLC/POUs/Accelerator/FB_Hgvpu.TcPOU
@@ -1,0 +1,136 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <POU Name="FB_Hgvpu" Id="{8947838d-e4b5-4cb8-b661-9299e64a0856}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Hgvpu
+VAR_INPUT
+	
+END_VAR
+
+VAR_OUTPUT
+END_VAR
+
+
+VAR
+    // From lcls-srv01: grep -e KDes  /u1/lcls/epics/ioc/data/ioc-undh-uc*/iocInfo/IOC.pvlist |sort
+
+    {attribute 'pytmc' := 'pv: 24; link: 2450:'}
+    fbSegment_24 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 25; link: 2550:'}
+    fbSegment_25 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 26; link: 2650:'}
+    fbSegment_26 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 27; link: 2750:'}
+    fbSegment_27 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 29; link: 2950:'}
+    fbSegment_29 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 30; link: 3050:'}
+    fbSegment_30 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 31; link: 3150:'}
+    fbSegment_31 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 32; link: 3250:'}
+    fbSegment_32 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 33; link: 3350:'}
+    fbSegment_33 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 34; link: 3450:'}
+    fbSegment_34 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 35; link: 3550:'}
+    fbSegment_35 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 36; link: 3650:'}
+    fbSegment_36 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 37; link: 3750:'}
+    fbSegment_37 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 38; link: 3850:'}
+    fbSegment_38 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 39; link: 3950:'}
+    fbSegment_39 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 40; link: 4050:'}
+    fbSegment_40 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 41; link: 4150:'}
+    fbSegment_41 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 42; link: 4250:'}
+    fbSegment_42 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 43; link: 4350:'}
+    fbSegment_43 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 44; link: 4450:'}
+    fbSegment_44 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 45; link: 4550:'}
+    fbSegment_45 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 46; link: 4650:'}
+    fbSegment_46 : FB_UndulatorSegment;
+    
+    fbSegment : ARRAY [iLowBound..iHighBound] OF POINTER TO FB_UndulatorSegment;
+    fbCurrentSegment : REFERENCE TO FB_UndulatorSegment;
+
+    iIndex : UDINT;
+
+    bInitialized : BOOL := FALSE;
+
+END_VAR
+
+VAR CONSTANT
+    iLowBound  : UDINT := 24;
+    iHighBound : UDINT := 46;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[IF NOT bInitialized THEN
+
+    fbSegment[24] := ADR(fbSegment_24);
+    fbSegment[25] := ADR(fbSegment_25);
+    fbSegment[26] := ADR(fbSegment_26);
+    fbSegment[27] := ADR(fbSegment_27);
+    fbSegment[28] := 0;
+    fbSegment[29] := ADR(fbSegment_29);
+    fbSegment[30] := ADR(fbSegment_30);
+    fbSegment[31] := ADR(fbSegment_31);
+    fbSegment[32] := ADR(fbSegment_32);
+    fbSegment[33] := ADR(fbSegment_33);
+    fbSegment[34] := ADR(fbSegment_34);
+    fbSegment[35] := ADR(fbSegment_35);
+    fbSegment[36] := ADR(fbSegment_36);
+    fbSegment[37] := ADR(fbSegment_37);
+    fbSegment[38] := ADR(fbSegment_38);
+    fbSegment[39] := ADR(fbSegment_39);
+    fbSegment[40] := ADR(fbSegment_40);
+    fbSegment[41] := ADR(fbSegment_41);
+    fbSegment[42] := ADR(fbSegment_42);
+    fbSegment[43] := ADR(fbSegment_43);
+    fbSegment[44] := ADR(fbSegment_44);
+    fbSegment[45] := ADR(fbSegment_45);
+    fbSegment[46] := ADR(fbSegment_46);
+
+    bInitialized := TRUE;
+END_IF
+
+FOR iIndex := iLowBound TO iHighBound DO
+    IF fbSegment[iIndex] <> 0 THEN
+		fbCurrentSegment REF= fbSegment[iIndex]^;
+		fbCurrentSegment();
+    END_IF
+END_FOR
+
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/Arbiter/ArbiterPLC/POUs/Accelerator/FB_SXU.TcPOU
+++ b/Arbiter/ArbiterPLC/POUs/Accelerator/FB_SXU.TcPOU
@@ -1,0 +1,136 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <POU Name="FB_SXU" Id="{23188e56-6a28-4c8b-9089-611f5a306284}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_SXU
+VAR_INPUT
+	
+END_VAR
+
+VAR_OUTPUT
+END_VAR
+
+
+
+VAR
+    // From lcls-srv01: grep -e KDes  /u1/lcls/epics/ioc/data/sioc-unds-uc*/iocInfo/IOC.pvlist |sort
+
+
+    {attribute 'pytmc' := 'pv: 26; link: 2650:'}
+    fbSegment_26 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 27; link: 2750:'}
+    fbSegment_27 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 28; link: 2850:'}
+    fbSegment_28 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 29; link: 2950:'}
+    fbSegment_29 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 30; link: 3050:'}
+    fbSegment_30 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 31; link: 3150:'}
+    fbSegment_31 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 32; link: 3250:'}
+    fbSegment_32 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 33; link: 3350:'}
+    fbSegment_33 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 34; link: 3450:'}
+    fbSegment_34 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 36; link: 3650:'}
+    fbSegment_36 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 37; link: 3750:'}
+    fbSegment_37 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 38; link: 3850:'}
+    fbSegment_38 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 39; link: 3950:'}
+    fbSegment_39 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 40; link: 4050:'}
+    fbSegment_40 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 41; link: 4150:'}
+    fbSegment_41 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 42; link: 4250:'}
+    fbSegment_42 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 43; link: 4350:'}
+    fbSegment_43 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 44; link: 4450:'}
+    fbSegment_44 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 45; link: 4550:'}
+    fbSegment_45 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 46; link: 4650:'}
+    fbSegment_46 : FB_UndulatorSegment;
+    
+    {attribute 'pytmc' := 'pv: 47; link: 4750:'}
+    fbSegment_47 : FB_UndulatorSegment;
+    
+
+
+    fbSegment : ARRAY [iLowBound..iHighBound] OF POINTER TO FB_UndulatorSegment;
+    fbCurrentSegment : REFERENCE TO FB_UndulatorSegment;
+
+    iIndex : UDINT;
+
+    bInitialized : BOOL := FALSE;
+
+END_VAR
+
+VAR CONSTANT
+    iLowBound  : UDINT := 26;
+    iHighBound : UDINT := 47;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[
+
+IF NOT bInitialized THEN
+
+    fbSegment[26] := ADR(fbSegment_26);
+    fbSegment[27] := ADR(fbSegment_27);
+    fbSegment[28] := ADR(fbSegment_28);
+    fbSegment[29] := ADR(fbSegment_29);
+    fbSegment[30] := ADR(fbSegment_30);
+    fbSegment[31] := ADR(fbSegment_31);
+    fbSegment[32] := ADR(fbSegment_32);
+    fbSegment[33] := ADR(fbSegment_33);
+    fbSegment[34] := ADR(fbSegment_34);
+    fbSegment[35] := 0;
+    fbSegment[36] := ADR(fbSegment_36);
+    fbSegment[37] := ADR(fbSegment_37);
+    fbSegment[38] := ADR(fbSegment_38);
+    fbSegment[39] := ADR(fbSegment_39);
+    fbSegment[40] := ADR(fbSegment_40);
+    fbSegment[41] := ADR(fbSegment_41);
+    fbSegment[42] := ADR(fbSegment_42);
+    fbSegment[43] := ADR(fbSegment_43);
+    fbSegment[44] := ADR(fbSegment_44);
+    fbSegment[45] := ADR(fbSegment_45);
+    fbSegment[46] := ADR(fbSegment_46);
+    fbSegment[47] := ADR(fbSegment_47);
+
+    bInitialized := TRUE;
+END_IF
+
+FOR iIndex := iLowBound TO iHighBound DO
+    IF fbSegment[iIndex] <> 0 THEN
+		fbCurrentSegment REF= fbSegment[iIndex]^;
+		fbCurrentSegment();
+    END_IF
+END_FOR]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/Arbiter/ArbiterPLC/POUs/Accelerator/FB_UndulatorSegment.TcPOU
+++ b/Arbiter/ArbiterPLC/POUs/Accelerator/FB_UndulatorSegment.TcPOU
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <POU Name="FB_UndulatorSegment" Id="{986484f4-a7ca-4f8c-bada-b360e7740d21}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_UndulatorSegment
+VAR_INPUT
+END_VAR
+VAR_OUTPUT
+END_VAR
+VAR
+	{attribute 'pytmc' := '
+		pv: KDes
+		link: KDes
+	'}
+	fbKDesired : FB_LREALFromEPICS;
+
+	{attribute 'pytmc' := '
+		pv: KAct
+		link: KAct
+	'}
+	fbKActual : FB_LREALFromEPICS;
+
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[fbKDesired();
+fbKActual();]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/Arbiter/ArbiterPLC/POUs/MAIN.TcPOU
+++ b/Arbiter/ArbiterPLC/POUs/MAIN.TcPOU
@@ -13,6 +13,18 @@ VAR
     nErrID     : UDINT;
     sOut       : T_MaxString;   
 
+	{attribute 'pytmc' := '
+		pv: Arbiter:Link:HGVPU
+		link: USEG:UNDH:
+	'}
+	fbHgvpu : FB_Hgvpu;
+	
+	{attribute 'pytmc' := '
+		pv: Arbiter:Link:SXU
+		link: USEG:UNDS:
+	'}
+	fbSxu : FB_SXU;
+	
 END_VAR
 ]]></Declaration>
     <Implementation>


### PR DESCRIPTION
KDes, KAct for all undulators

* Not yet rebuilt here, but working in my own test project
* May require update to lcls-twincat-general
* Should be rebuilt/tested prior to merging

Test project watch results, with actual values coming out of the gateway:

SXU
<img width="843" alt="image" src="https://user-images.githubusercontent.com/5139267/75908311-bf40e900-5dfe-11ea-85d0-cbfb29b6a712.png">

HGVPU
<img width="611" alt="image" src="https://user-images.githubusercontent.com/5139267/75908387-e3042f00-5dfe-11ea-9ead-94d265b0a323.png">

This is run by configuring EPICS to look at the gateway on psdev, which allows it also to talk to the PLCs on the test network:
```
#!/bin/bash

export EPICS_CA_AUTO_ADDR_LIST=YES
export EPICS_CA_ADDR_LIST="134.79.219.255 134.79.151.21:5068"
export EPICS_CA_REPEATER_PORT=5067
export EPICS_CA_SERVER_PORT=5066

./st.cmd
```